### PR TITLE
shift+space in "ro" locale

### DIFF
--- a/xkb-data_xmod/xkb/symbols/ro
+++ b/xkb-data_xmod/xkb/symbols/ro
@@ -56,6 +56,8 @@ xkb_symbols "basic" {
     key <AB08> { [ comma, 	        less,  guillemotleft	          ] };
     key <AB09> { [ period, 	     greater,  guillemotright 	          ] };
 
+    key <SPCE> { [        space,        space,           space,     nobreakspace ] };
+
     include "level3(ralt_switch)"
 };
 


### PR DESCRIPTION
I noticed shift+space didn't work in the "ro" locale (instead of "space", xev showed a "NoSymbol"), so I copied this line from the "us" locale and it's working now. 