### PR TITLE
Add DH variant of the bg(colemak) layout

### DIFF
--- a/xkb-data_xmod/xkb/rules/base.lst
+++ b/xkb-data_xmod/xkb/rules/base.lst
@@ -427,6 +427,7 @@
   bas_phonetic    bg: Bulgarian (new phonetic)
   bekl            bg: Bulgarian (enhanced)
   colemak         bg: Bulgarian (Colemak, phonetic S-Slavic)
+  colemak_dh      bg: Bulgarian (Colemak-DH, phonetic S-Slavic)
   azerty-deadkeys dz: Kabyle (AZERTY, with dead keys)
   qwerty-gb-deadkeys dz: Kabyle (QWERTY, UK, with dead keys)
   qwerty-us-deadkeys dz: Kabyle (QWERTY, US, with dead keys)

--- a/xkb-data_xmod/xkb/rules/base.xml
+++ b/xkb-data_xmod/xkb/rules/base.xml
@@ -2715,6 +2715,12 @@
             <name>colemak</name>
             <description>Bulgarian (Colemak, phonetic S-Slavic)</description>
           </configItem>
+        </variant>
+        <variant>
+          <configItem>
+            <name>colemak_dh</name>
+            <description>Bulgarian (Colemak-DH, phonetic S-Slavic)</description>
+          </configItem>
         </variant>    <!--  <-<  DreymaR  -->
       </variantList>
     </layout>

--- a/xkb-data_xmod/xkb/rules/evdev.lst
+++ b/xkb-data_xmod/xkb/rules/evdev.lst
@@ -427,6 +427,7 @@
   bas_phonetic    bg: Bulgarian (new phonetic)
   bekl            bg: Bulgarian (enhanced)
   colemak         bg: Bulgarian (Colemak, phonetic S-Slavic)
+  colemak_dh      bg: Bulgarian (Colemak-DH, phonetic S-Slavic)
   azerty-deadkeys dz: Kabyle (AZERTY, with dead keys)
   qwerty-gb-deadkeys dz: Kabyle (QWERTY, UK, with dead keys)
   qwerty-us-deadkeys dz: Kabyle (QWERTY, US, with dead keys)

--- a/xkb-data_xmod/xkb/rules/evdev.xml
+++ b/xkb-data_xmod/xkb/rules/evdev.xml
@@ -2715,6 +2715,12 @@
             <name>colemak</name>
             <description>Bulgarian (Colemak, phonetic S-Slavic)</description>
           </configItem>
+        </variant>
+        <variant>
+          <configItem>
+            <name>colemak_dh</name>
+            <description>Bulgarian (Colemak-DH, phonetic S-Slavic)</description>
+          </configItem>
         </variant>    <!--  <-<  DreymaR  -->
       </variantList>
     </layout>

--- a/xkb-data_xmod/xkb/symbols/bg
+++ b/xkb-data_xmod/xkb/symbols/bg
@@ -394,4 +394,37 @@ xkb_symbols "colemak" {
 
     include "level3(ralt_switch)"
 };
+
+partial xkb_symbols "colemak_dh" {
+    include "bg(colemak)"
+    name[Group1]= "Bulgarian (Colemak-DH, phonetic S-Slavic)";
+    include "bg(colemak_dbg)"
+    include "bg(colemak_hm)"
+};
+
+hidden partial xkb_symbols "colemak_dhk" {
+    include "bg(colemak)"
+    name[Group1]= "Bulgarian (Colemak-DHk, phonetic S-Slavic)";
+    include "bg(colemak_dbg)"
+    include "bg(colemak_hmk)"
+};
+
+hidden partial xkb_symbols "colemak_dbg" {
+    key <AD05> { [     Cyrillic_be,     Cyrillic_BE,               b,               B ] };
+    key <AC05> { [    Cyrillic_ghe,    Cyrillic_GHE,               g,               G ] };
+    key <AB04> { [     Cyrillic_de,     Cyrillic_DE,               d,               D ] };
+    key <AB05> { [     Cyrillic_ve,     Cyrillic_VE,               v,               V ] };
+};
+
+hidden partial xkb_symbols "colemak_hm" {
+    key <AC06> { [     Cyrillic_em,     Cyrillic_EM,               m,               M ] };
+    key <AB07> { [     Cyrillic_ha,     Cyrillic_HA,               h,               H ] };
+};
+
+hidden partial xkb_symbols "colemak_hmk" {
+    key <AC06> { [     Cyrillic_ka,     Cyrillic_KA,               k,               K ] };
+    key <AC06> { [     Cyrillic_em,     Cyrillic_EM,               m,               M ] };
+    key <AB07> { [     Cyrillic_ha,     Cyrillic_HA,               h,               H ] };
+};
+
 //  <--<< DreymaR: Additions to xkb/symbols/bg


### PR DESCRIPTION
Currently, it does _not_ observe the `misc:cmk_curl_dh` option, but is instead implemented as a separate keyboard layout / xkb symbols layer.