### PR TITLE
Fix swapped `'` and `-` keys for Sym Wide-ANSI variant

### DIFF
--- a/xkb-data_xmod/xkb/symbols/symkeys
+++ b/xkb-data_xmod/xkb/symbols/symkeys
@@ -59,10 +59,10 @@ xkb_symbols "cmk_ed_sym_w-104" {
 //    include "symkeys(cmk_ed_numbers)"
     key <AE11> { [         equal,          plus,    dead_doubleacute,            notequal ] }; // =+ _≠
     key <AE12> { [     backslash,           bar,          dead_grave,           brokenbar ] }; // \| _¦
-    key <AD10> { [         minus,    underscore,         dead_macron,           plusminus ] }; // -_ _±
+    key <AD10> { [    apostrophe,      quotedbl,          dead_acute,               U2032 ] }; // '" _′
 //    key <AD11> { [   bracketleft,     braceleft,               aring,               Aring ] }; // [{ åÅ
 //    key <AD12> { [  bracketright,    braceright,                  ae,                  AE ] }; // ]} æÆ
-//    key <AC11> { [    apostrophe,      quotedbl,          dead_acute,               U2032 ] }; // '" _′
+    key <AC11> { [         minus,    underscore,         dead_macron,           plusminus ] }; // -_ _±
     key <BKSL> { [     semicolon,         colon,      dead_diaeresis,            ellipsis ] }; // QWE P Cmk ;: ¨…
 //    key <AB10> { [         slash,      question,         dead_stroke,        questiondown ] }; // /? _¿
 };


### PR DESCRIPTION
### What went wrong
On Wide-ANSI keyboards with symbol key mods, the `'` and `-` keys were swapped.

### What this fixes
Swaps their positions back to the expected layout.